### PR TITLE
Remove unnecessary text="MountView" and "Virtual Keyboard"

### DIFF
--- a/usr/share/enigma2/PLi-HD-FullNight/skin.xml
+++ b/usr/share/enigma2/PLi-HD-FullNight/skin.xml
@@ -1667,7 +1667,6 @@
 	<screen name="AutoMountView" position="fill" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
 		<panel name="ButtonTemplate_RYS"/>
-		<eLabel text="MountView" position="25,30" size="1085,55" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center"/>
 		<widget source="legend1" render="Label" position="590,110" size="130,50" transparent="1" zPosition="1" font="Regular;18" valign="center" halign="Left"/>
 		<widget source="legend2" render="Label" position="720,110" size="345,50" transparent="1" zPosition="1" font="Regular;18" valign="center" halign="center"/>
 		<widget source="legend3" render="Label" position="1065,110" size="130,50" transparent="1" zPosition="1" font="Regular;18" valign="center" halign="center"/>
@@ -2293,7 +2292,6 @@ self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (or
 
 	<screen name="VirtualKeyBoard" position="fill" zPosition="99" flags="wfNoBorder">
 		<panel name="PigTemplate"/>
-		<eLabel text="Virtual KeyBoard" position="25,30" size="1085,55" backgroundColor="secondBG" transparent="1" zPosition="1" font="Regular;24" valign="center"/>
 		<panel name="ButtonTemplate_RGY"/>
 		<eLabel text="Delete" render="Label" position="185,682" size="220,28" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;24"/>
 		<eLabel text="OK" render="Label" position="460,682" size="220,28" backgroundColor="darkgrey" zPosition="2" transparent="1" foregroundColor="grey" font="Regular;24"/>


### PR DESCRIPTION
Text is displayed twice (English text from skin and translated text from enigma) when in -mount view- menu(networkbrowser) or using virtual keyboard.