### PR TITLE
Use floor division to fix crash with python 3

### DIFF
--- a/usr/share/enigma2/PLi-HD-FullNight/skin.xml
+++ b/usr/share/enigma2/PLi-HD-FullNight/skin.xml
@@ -2005,7 +2005,7 @@ if self.type == self.TYPE_YESNO:
 	self[&quot;list&quot;].instance.move(ePoint(2, wsizey - lenlist + titleheight - 2))
 	self[&quot;list&quot;].instance.resize(eSize(*listsize))
 newwidth = wsize[0]
-self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth)/2, orgpos.y() + (orgheight - wsizey)/2))
+self.instance.move(ePoint(orgpos.x() + (orgwidth - newwidth) // 2, orgpos.y() + (orgheight - wsizey) // 2))
 	</applet>
 	</screen>
 


### PR DESCRIPTION
Fixes crash:

File "/usr/lib/enigma2/python/Screens/Screen.py", line 270, in createGUIScreen
    exec(f, globals(), locals())  # Python 3
  File "skin applet", line 43, in <module>
  File "/usr/lib/enigma2/python/enigma.py", line 1240, in __init__
    _enigma.ePoint_swiginit(self, _enigma.new_ePoint(*args))
TypeError: in method 'new_ePoint', argument 1 of type 'int'